### PR TITLE
Update dependencies and plugins

### DIFF
--- a/THIRD-PARTY.txt
+++ b/THIRD-PARTY.txt
@@ -2,5 +2,5 @@
 Lists of 4 third-party dependencies.
      (Apache License version 2.0) AWS Lambda Java Core Library (com.amazonaws:aws-lambda-java-core:1.2.3 - https://aws.amazon.com/lambda/)
      (Apache License version 2.0) JetBrains Java Annotations (org.jetbrains:annotations:26.0.2 - https://github.com/JetBrains/java-annotations)
-     (Public Domain) JSON in Java (org.json:json:20250107 - https://github.com/douglascrockford/JSON-java)
+     (Public Domain) JSON in Java (org.json:json:20250517 - https://github.com/douglascrockford/JSON-java)
      (MIT License) SLF4J API Module (org.slf4j:slf4j-api:2.0.17 - http://www.slf4j.org)

--- a/json-logger/pom.xml
+++ b/json-logger/pom.xml
@@ -45,7 +45,7 @@
     <dependency>
       <artifactId>json</artifactId>
       <groupId>org.json</groupId>
-      <version>20250107</version>
+      <version>20250517</version>
     </dependency>
     <dependency>
       <artifactId>mockito-core</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -484,7 +484,7 @@
   <properties>
     <java.version>11</java.version>
     <javadoc-plugin.version>3.11.2</javadoc-plugin.version>
-    <junit.version>5.12.0</junit.version>
+    <junit.version>5.12.1</junit.version>
     <mockito.version>5.16.0</mockito.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <slf4j.version>2.0.17</slf4j.version>

--- a/pom.xml
+++ b/pom.xml
@@ -485,7 +485,7 @@
     <java.version>11</java.version>
     <javadoc-plugin.version>3.11.2</javadoc-plugin.version>
     <junit.version>5.12.2</junit.version>
-    <mockito.version>5.16.1</mockito.version>
+    <mockito.version>5.17.0</mockito.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <slf4j.version>2.0.17</slf4j.version>
     <system-stubs.version>2.1.7</system-stubs.version>

--- a/pom.xml
+++ b/pom.xml
@@ -485,7 +485,7 @@
     <java.version>11</java.version>
     <javadoc-plugin.version>3.11.2</javadoc-plugin.version>
     <junit.version>5.12.1</junit.version>
-    <mockito.version>5.16.0</mockito.version>
+    <mockito.version>5.16.1</mockito.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <slf4j.version>2.0.17</slf4j.version>
     <system-stubs.version>2.1.7</system-stubs.version>

--- a/pom.xml
+++ b/pom.xml
@@ -357,7 +357,7 @@
   </issueManagement>
   <licenses>
     <license>
-      <comments>See NOTICE for third-party licenses.</comments>
+      <comments>See THIRD-PARTY.txt for third-party licenses.</comments>
       <distribution>repo</distribution>
       <name>Apache-2.0</name>
       <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
@@ -383,7 +383,7 @@
                   <configuration>
                     <addJavaLicenseAfterPackage>false</addJavaLicenseAfterPackage>
                     <excludeTransitiveDependencies>true</excludeTransitiveDependencies>
-                    <excludedGroups>io\.github\.vitalijr2\.logging</excludedGroups>
+                    <excludedGroups>^io\.github\.vitalijr2</excludedGroups>
                     <excludedScopes>test</excludedScopes>
                     <excludes>
                       <exclude>**/package-info.java</exclude>

--- a/pom.xml
+++ b/pom.xml
@@ -485,7 +485,7 @@
     <java.version>11</java.version>
     <javadoc-plugin.version>3.11.2</javadoc-plugin.version>
     <junit.version>5.12.2</junit.version>
-    <mockito.version>5.17.0</mockito.version>
+    <mockito.version>5.18.0</mockito.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <slf4j.version>2.0.17</slf4j.version>
     <system-stubs.version>2.1.8</system-stubs.version>

--- a/pom.xml
+++ b/pom.xml
@@ -146,7 +146,7 @@
             </execution>
           </executions>
           <groupId>org.apache.maven.plugins</groupId>
-          <version>3.5.2</version>
+          <version>3.5.3</version>
         </plugin>
         <plugin>
           <artifactId>maven-jar-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -484,7 +484,7 @@
   <properties>
     <java.version>11</java.version>
     <javadoc-plugin.version>3.11.2</javadoc-plugin.version>
-    <junit.version>5.12.1</junit.version>
+    <junit.version>5.12.2</junit.version>
     <mockito.version>5.16.1</mockito.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <slf4j.version>2.0.17</slf4j.version>

--- a/pom.xml
+++ b/pom.xml
@@ -107,7 +107,7 @@
             </execution>
           </executions>
           <groupId>org.jacoco</groupId>
-          <version>0.8.12</version>
+          <version>0.8.13</version>
         </plugin>
         <plugin>
           <artifactId>maven-clean-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -211,7 +211,7 @@
             </properties>
           </configuration>
           <groupId>org.apache.maven.plugins</groupId>
-          <version>3.5.2</version>
+          <version>3.5.3</version>
         </plugin>
         <plugin>
           <artifactId>semver-maven-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -488,7 +488,7 @@
     <mockito.version>5.17.0</mockito.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <slf4j.version>2.0.17</slf4j.version>
-    <system-stubs.version>2.1.7</system-stubs.version>
+    <system-stubs.version>2.1.8</system-stubs.version>
   </properties>
   <scm>
     <connection>scm:git:https://github.com/vitalijr2/aws-lambda-slf4j.git</connection>


### PR DESCRIPTION
- Bump JSON to 20250517
- Bump jUnit to 5.12.2
- Bump Mockito to 5.18.0
- Bump System Stubs to 2.1.8
- Bump failsafe and surefire plugins to 3.5.3
- Bump jacoco to 0.8.13